### PR TITLE
Bust Cache

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -80,6 +80,26 @@ resource "aws_cloudfront_distribution" "main" {
     max_ttl                = 1200
   }
 
+  ordered_cache_behavior {
+    target_origin_id = "origin-${var.fqdn}"
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods = ["GET", "HEAD"]
+    path_pattern = "index.html"
+    
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl = 0
+    default_ttl = 0
+    max_ttl = 0
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"


### PR DESCRIPTION
We should only need to disable cache on index.html. If we do this, users will always have the most up to date version of our app. Other resources (js/css/etc) can remain cached, as their filenames are hashed when referenced from index.html.

http://create-react-app.dev/docs/production-build/#static-file-caching